### PR TITLE
Fix performance (remove a lot of unnecessary allocs and drops)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 use std::io::{BufReader, Cursor, Read, Seek};
 
-use ::libipld::cid::Cid;
-use ::libipld::cbor::{cbor, cbor::MajorKind, DagCbor, decode};
+use ::libipld::cbor::{cbor, cbor::MajorKind, decode};
 use ::libipld::cbor::error::LengthOutOfRange;
-use ::libipld::prelude::{Codec, Decode};
+use ::libipld::cid::Cid;
 use anyhow::Result;
 use futures::{executor, stream::StreamExt};
 use iroh_car::{CarHeader, CarReader, Error};
@@ -109,7 +108,7 @@ fn decode_dag_cbor_to_pyobject<R: Read + Seek>(py: Python, r: &mut R) -> Result<
 #[pyfunction]
 fn decode_dag_cbor_multi<'py>(py: Python<'py>, data: &[u8]) -> PyResult<&'py PyList> {
     let mut reader = BufReader::new(Cursor::new(data));
-    let mut decoded_parts = PyList::empty(py);
+    let decoded_parts = PyList::empty(py);
 
     loop {
         let py_object = decode_dag_cbor_to_pyobject(py, &mut reader);


### PR DESCRIPTION
> Ipld allocated and dropped with short living time

from #7

### Before:
```txt
Hello World Decode:
===================
libipld  : 243 ns

Realistic Decode Tests:
=======================
citm_catalog.json.dagcbor      libipld  : 9.55 ms (34.18 MB/s)
canada.json.dagcbor            libipld  : 11.01 ms (91.46 MB/s)
twitter.json.dagcbor           libipld  : 3.27 ms (117.36 MB/s)
```

### After:
```txt
Hello World Decode:
===================
libipld  : 263 ns

Realistic Decode Tests:
=======================
citm_catalog.json.dagcbor      libipld  : 4.61 ms (70.81 MB/s)
canada.json.dagcbor            libipld  : 6.69 ms (150.66 MB/s)
twitter.json.dagcbor           libipld  : 2.53 ms (151.70 MB/s)
```

- citm_catalog.json.dagcbor **x2**
- canada.json.dagcbor **x1.64**
- twitter.json.dagcbor **x1.29**