### PR TITLE
Encode and decode CID as bytes (major 2) instead of string (major 3)

### DIFF
--- a/pytests/test_cid.py
+++ b/pytests/test_cid.py
@@ -1,5 +1,19 @@
 import libipld
 
 
-def test_cid_decode() -> None:
-    libipld.decode_cid('bafyreig7jbijxpn4lfhvnvyuwf5u5jyhd7begxwyiqe7ingwxycjdqjjoa')
+def test_cid_decode_multibase() -> None:
+    cid = libipld.decode_cid('bafyreig7jbijxpn4lfhvnvyuwf5u5jyhd7begxwyiqe7ingwxycjdqjjoa')
+    assert 1 == cid['version']
+    assert 113 == cid['codec']
+    assert 18 == cid['hash']['code']
+    assert 32 == cid['hash']['size']
+    assert cid['hash']['size'] == len(cid['hash']['digest'])
+
+
+def test_cid_decode_raw() -> None:
+    cid = libipld.decode_cid(b'\x01q\x12 \xb6\x81\x1a\x1d\x7f\x8c\x17\x91\xdam\x1bO\x13m\xc0\xe2&y\xea\xfe\xaaX\xd6M~/\xaa\xd5\x89\x0e\x9d\x9c')
+    assert 1 == cid['version']
+    assert 113 == cid['codec']
+    assert 18 == cid['hash']['code']
+    assert 32 == cid['hash']['size']
+    assert cid['hash']['size'] == len(cid['hash']['digest'])

--- a/pytests/test_decode_car.py
+++ b/pytests/test_decode_car.py
@@ -22,8 +22,8 @@ def test_decode_car(benchmark, car) -> None:
     assert 1 == len(header['roots'])
 
     assert isinstance(blocks, dict)
-    assert all(isinstance(k, str) for k in blocks.keys())
-    assert all(len(k) == 59 for k in blocks.keys())
+    assert all(isinstance(k, bytes) for k in blocks.keys())
+    assert all(len(k) == 36 for k in blocks.keys())
     assert all(isinstance(v, dict) for v in blocks.values())
     assert all(v for v in blocks.values())  # not empty dict
 


### PR DESCRIPTION
this matches specification and gives perf boost 

https://ipld.io/specs/codecs/dag-cbor/spec/#links

> In DAG-CBOR, [Links](https://ipld.io/docs/data-model/kinds/#link-kind) are the binary form of a [CID](https://ipld.io/glossary/#cid) encoded using the raw-binary identity [Multibase](https://github.com/multiformats/multibase). That is, the Multibase identity prefix (0x00) is prepended to the binary form of a CID and this new byte array is encoded into CBOR as a byte-string (major type 2), and associated with CBOR tag 42.