### PR TITLE
Test PGO gather segfault

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -32,7 +32,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Compile.
-        run: pip install -v -e .
+        run: pip install -v -e . --config-settings=build-args='--profile profiling'
         env:
           RUSTFLAGS: "-Cprofile-generate=${{ github.workspace }}/profdata"
 
@@ -43,7 +43,7 @@ jobs:
         run: rustup run stable bash -c '$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/profdata'
 
       - name: Compile with profile.
-        run: pip install -v -e .
+        run: pip install -v -e . --config-settings=build-args='--profile profiling'
         env:
           RUSTFLAGS: "-Cprofile-use=${{ github.workspace }}/merged.profdata"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,8 @@ debug = false
 incremental = false
 lto = true
 opt-level = 3
+
+[profile.profiling]
+inherits = "release"
+debug = true
+strip = false


### PR DESCRIPTION
this branch is based on changes before unsafe code parts with pyo3 ffi 

upd. crashed. force pushed to the last stable release (v1.2.3)