### PR TITLE
packaging: Use well known Repository project.urls key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = [
     {name = "Ilya (Marshal)", email = "ilya@marshal.dev"}
 ]
 license = "MIT"
-repository = "https://github.com/MarshalX/python-libipld"
 readme = "README.md"
 keywords = ["library", "lib", "ipld", "cid", "multibase", "multihash", "dag", "cbor", "dag-cbor"]
 requires-python = ">=3.8"
@@ -34,6 +33,7 @@ classifiers = [
 
 [project.urls]
 "Homepage" = "https://github.com/MarshalX/python-libipld"
+"Repository" = "https://github.com/MarshalX/python-libipld"
 "Tracker" = "https://github.com/MarshalX/python-libipld/issues"
 "Author" = "https://github.com/MarshalX"
 


### PR DESCRIPTION
The VSCode extension Better TOML reported project.repository as an invalid key (I assume it's based on a schema file somewhere). The PyPA packaging guide also says to use project.urls, with a well known key.

See
- https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls