### PR TITLE
Add Python 3.14 builds; bump test dependencies to match

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   UV_FROZEN: true
-  UV_PYTHON: 3.13 # use the latest version of Python because it is faster
+  UV_PYTHON: 3.14 # use the latest version of Python because it is faster
   RUST_VERSION: "1.87.0"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,10 @@ jobs:
           - os: windows
             target: i686
             python-architecture: x86
-            interpreter: 3.8 3.9 3.10 3.11 3.12 3.13
+            interpreter: 3.8 3.9 3.10 3.11 3.12 3.13 3.14
           - os: windows
             target: aarch64
-            interpreter: 3.11 3.12 3.13
+            interpreter: 3.11 3.12 3.13 3.14
 
           - os: macos
             target: x86_64
@@ -54,13 +54,13 @@ jobs:
             target: aarch64
           - os: ubuntu
             target: armv7
-            interpreter: 3.8 3.9 3.10 3.11 3.12 3.13
+            interpreter: 3.8 3.9 3.10 3.11 3.12 3.13 3.14
           - os: ubuntu
             target: ppc64le
-            interpreter: 3.8 3.9 3.10 3.11 3.12 3.13
+            interpreter: 3.8 3.9 3.10 3.11 3.12 3.13 3.14
           - os: ubuntu
             target: s390x
-            interpreter: 3.8 3.9 3.10 3.11 3.12 3.13
+            interpreter: 3.8 3.9 3.10 3.11 3.12 3.13 3.14
 
           - os: ubuntu
             target: x86_64
@@ -93,7 +93,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
-          args: --release --out dist --interpreter ${{ matrix.interpreter || '3.8 3.9 3.10 3.11 3.12 3.13 pypy3.9 pypy3.10 pypy3.11' }}
+          args: --release --out dist --interpreter ${{ matrix.interpreter || '3.8 3.9 3.10 3.11 3.12 3.13 3.14 pypy3.9 pypy3.10 pypy3.11' }}
           rust-toolchain: ${{ env.RUST_VERSION }}
           docker-options: -e CI
 
@@ -112,7 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-13, macos-14 ]
-        interpreter: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        interpreter: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         exclude:
           # actions/setup-python@v5 does not support 3.8 and 3.9 on arm64
           - os: macos-14
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Get dist artifacts.
         uses: actions/download-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Pre-processors",
@@ -38,16 +39,19 @@ classifiers = [
 "Author" = "https://github.com/MarshalX"
 
 [dependency-groups]
-dev = ["maturin>=1.2,<2.0"]
+dev = ["maturin>=1.8.7,<2.0"]
 testing = [
     { include-group = "dev" },
-    "pytest==8.3.5",
-    "pytest-benchmark==4.0.0",
-    "pytest-xdist==3.6.1",
+    'pytest==8.3.5; python_version == "3.8"',
+    'pytest==8.4.1; python_version >= "3.9"',
+    'pytest-benchmark==4.0.0; python_version == "3.8"',
+    'pytest-benchmark==5.1.0; python_version >= "3.9"',
+    'pytest-xdist==3.6.1; python_version == "3.8"',
+    'pytest-xdist==3.8.0; python_version >= "3.9"',
 ]
 codspeed = [
     # only run on CI with the latest Python version
-    'pytest-codspeed==3.2.0; python_version == "3.13" and implementation_name == "cpython"',
+    'pytest-codspeed==3.2.0; python_version == "3.14" and implementation_name == "cpython"',
 ]
 
 all = [
@@ -68,5 +72,5 @@ bindings = "pyo3"
 features = ["pyo3/extension-module"]
 
 [build-system]
-requires = ["maturin>=1.2,<2.0"]
+requires = ["maturin>=1.8.7,<2.0"]
 build-backend = "maturin"

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,10 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version == '3.13.*' and implementation_name == 'cpython'",
-    "(python_full_version >= '3.9' and python_full_version < '3.13') or (python_full_version >= '3.9' and implementation_name != 'cpython') or (python_full_version >= '3.14' and implementation_name == 'cpython')",
+    "python_full_version == '3.14.*' and implementation_name == 'cpython'",
+    "(python_full_version >= '3.9' and python_full_version < '3.13') or (python_full_version >= '3.9' and implementation_name != 'cpython') or (python_full_version >= '3.15' and implementation_name == 'cpython')",
     "python_full_version < '3.9'",
 ]
 
@@ -12,7 +13,7 @@ name = "cffi"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "python_full_version == '3.13.*' and implementation_name == 'cpython'" },
+    { name = "pycparser", marker = "python_full_version == '3.14.*' and implementation_name == 'cpython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
 wheels = [
@@ -131,39 +132,51 @@ source = { editable = "." }
 [package.dev-dependencies]
 all = [
     { name = "maturin" },
-    { name = "pytest" },
-    { name = "pytest-benchmark" },
-    { name = "pytest-xdist" },
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest-benchmark", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-benchmark", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
 codspeed = [
-    { name = "pytest-codspeed", marker = "python_full_version == '3.13.*' and implementation_name == 'cpython'" },
+    { name = "pytest-codspeed", marker = "python_full_version == '3.14.*' and implementation_name == 'cpython'" },
 ]
 dev = [
     { name = "maturin" },
 ]
 testing = [
     { name = "maturin" },
-    { name = "pytest" },
-    { name = "pytest-benchmark" },
-    { name = "pytest-xdist" },
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest-benchmark", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-benchmark", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
 all = [
-    { name = "maturin", specifier = ">=1.2,<2.0" },
-    { name = "pytest", specifier = "==8.3.5" },
-    { name = "pytest-benchmark", specifier = "==4.0.0" },
-    { name = "pytest-xdist", specifier = "==3.6.1" },
+    { name = "maturin", specifier = ">=1.8.7,<2.0" },
+    { name = "pytest", marker = "python_full_version == '3.8.*'", specifier = "==8.3.5" },
+    { name = "pytest", marker = "python_full_version >= '3.9'", specifier = "==8.4.1" },
+    { name = "pytest-benchmark", marker = "python_full_version == '3.8.*'", specifier = "==4.0.0" },
+    { name = "pytest-benchmark", marker = "python_full_version >= '3.9'", specifier = "==5.1.0" },
+    { name = "pytest-xdist", marker = "python_full_version == '3.8.*'", specifier = "==3.6.1" },
+    { name = "pytest-xdist", marker = "python_full_version >= '3.9'", specifier = "==3.8.0" },
 ]
-codspeed = [{ name = "pytest-codspeed", marker = "python_full_version == '3.13.*' and implementation_name == 'cpython'", specifier = "==3.2.0" }]
-dev = [{ name = "maturin", specifier = ">=1.2,<2.0" }]
+codspeed = [{ name = "pytest-codspeed", marker = "python_full_version == '3.14.*' and implementation_name == 'cpython'", specifier = "==3.2.0" }]
+dev = [{ name = "maturin", specifier = ">=1.8.7,<2.0" }]
 testing = [
-    { name = "maturin", specifier = ">=1.2,<2.0" },
-    { name = "pytest", specifier = "==8.3.5" },
-    { name = "pytest-benchmark", specifier = "==4.0.0" },
-    { name = "pytest-xdist", specifier = "==3.6.1" },
+    { name = "maturin", specifier = ">=1.8.7,<2.0" },
+    { name = "pytest", marker = "python_full_version == '3.8.*'", specifier = "==8.3.5" },
+    { name = "pytest", marker = "python_full_version >= '3.9'", specifier = "==8.4.1" },
+    { name = "pytest-benchmark", marker = "python_full_version == '3.8.*'", specifier = "==4.0.0" },
+    { name = "pytest-benchmark", marker = "python_full_version >= '3.9'", specifier = "==5.1.0" },
+    { name = "pytest-xdist", marker = "python_full_version == '3.8.*'", specifier = "==3.6.1" },
+    { name = "pytest-xdist", marker = "python_full_version >= '3.9'", specifier = "==3.8.0" },
 ]
 
 [[package]]
@@ -171,7 +184,7 @@ name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mdurl", marker = "python_full_version == '3.13.*' and implementation_name == 'cpython'" },
+    { name = "mdurl", marker = "python_full_version == '3.14.*' and implementation_name == 'cpython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -237,7 +250,8 @@ version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.13.*' and implementation_name == 'cpython'",
-    "(python_full_version >= '3.9' and python_full_version < '3.13') or (python_full_version >= '3.9' and implementation_name != 'cpython') or (python_full_version >= '3.14' and implementation_name == 'cpython')",
+    "python_full_version == '3.14.*' and implementation_name == 'cpython'",
+    "(python_full_version >= '3.9' and python_full_version < '3.13') or (python_full_version >= '3.9' and implementation_name != 'cpython') or (python_full_version >= '3.15' and implementation_name == 'cpython')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
@@ -275,14 +289,16 @@ wheels = [
 name = "pytest"
 version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "iniconfig" },
-    { name = "packaging" },
+    { name = "colorama", marker = "python_full_version < '3.9' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.9'" },
+    { name = "iniconfig", marker = "python_full_version < '3.9'" },
+    { name = "packaging", marker = "python_full_version < '3.9'" },
     { name = "pluggy", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.9'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
 wheels = [
@@ -290,12 +306,38 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*' and implementation_name == 'cpython'",
+    "python_full_version == '3.14.*' and implementation_name == 'cpython'",
+    "(python_full_version >= '3.9' and python_full_version < '3.13') or (python_full_version >= '3.9' and implementation_name != 'cpython') or (python_full_version >= '3.15' and implementation_name == 'cpython')",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.9' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
+    { name = "iniconfig", marker = "python_full_version >= '3.9'" },
+    { name = "packaging", marker = "python_full_version >= '3.9'" },
+    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pygments", marker = "python_full_version >= '3.9'" },
+    { name = "tomli", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
 name = "pytest-benchmark"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
 dependencies = [
-    { name = "py-cpuinfo" },
-    { name = "pytest" },
+    { name = "py-cpuinfo", marker = "python_full_version < '3.9'" },
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/08/e6b0067efa9a1f2a1eb3043ecd8a0c48bfeb60d3255006dcc829d72d5da2/pytest-benchmark-4.0.0.tar.gz", hash = "sha256:fb0785b83efe599a6a956361c0691ae1dbb5318018561af10f3e915caa0048d1", size = 334641, upload-time = "2022-10-25T21:21:55.686Z" }
 wheels = [
@@ -303,13 +345,31 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-benchmark"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*' and implementation_name == 'cpython'",
+    "python_full_version == '3.14.*' and implementation_name == 'cpython'",
+    "(python_full_version >= '3.9' and python_full_version < '3.13') or (python_full_version >= '3.9' and implementation_name != 'cpython') or (python_full_version >= '3.15' and implementation_name == 'cpython')",
+]
+dependencies = [
+    { name = "py-cpuinfo", marker = "python_full_version >= '3.9'" },
+    { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/d0/a8bd08d641b393db3be3819b03e2d9bb8760ca8479080a26a5f6e540e99c/pytest-benchmark-5.1.0.tar.gz", hash = "sha256:9ea661cdc292e8231f7cd4c10b0319e56a2118e2c09d9f50e1b3d150d2aca105", size = 337810, upload-time = "2024-10-30T11:51:48.521Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/d6/b41653199ea09d5969d4e385df9bbfd9a100f28ca7e824ce7c0a016e3053/pytest_benchmark-5.1.0-py3-none-any.whl", hash = "sha256:922de2dfa3033c227c96da942d1878191afa135a29485fb942e85dff1c592c89", size = 44259, upload-time = "2024-10-30T11:51:45.94Z" },
+]
+
+[[package]]
 name = "pytest-codspeed"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "python_full_version == '3.13.*' and implementation_name == 'cpython'" },
-    { name = "pytest", marker = "python_full_version == '3.13.*' and implementation_name == 'cpython'" },
-    { name = "rich", marker = "python_full_version == '3.13.*' and implementation_name == 'cpython'" },
+    { name = "cffi", marker = "python_full_version == '3.14.*' and implementation_name == 'cpython'" },
+    { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.14.*' and implementation_name == 'cpython'" },
+    { name = "rich", marker = "python_full_version == '3.14.*' and implementation_name == 'cpython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/03/98/16fe3895b1b8a6d537a89eecb120b97358df8f0002c6ecd11555d6304dc8/pytest_codspeed-3.2.0.tar.gz", hash = "sha256:f9d1b1a3b2c69cdc0490a1e8b1ced44bffbd0e8e21d81a7160cfdd923f6e8155", size = 18409, upload-time = "2025-01-31T14:28:26.165Z" }
 wheels = [
@@ -330,9 +390,12 @@ wheels = [
 name = "pytest-xdist"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
 dependencies = [
-    { name = "execnet" },
-    { name = "pytest" },
+    { name = "execnet", marker = "python_full_version < '3.9'" },
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/41/c4/3c310a19bc1f1e9ef50075582652673ef2bfc8cd62afef9585683821902f/pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d", size = 84060, upload-time = "2024-04-28T19:29:54.414Z" }
 wheels = [
@@ -340,12 +403,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*' and implementation_name == 'cpython'",
+    "python_full_version == '3.14.*' and implementation_name == 'cpython'",
+    "(python_full_version >= '3.9' and python_full_version < '3.13') or (python_full_version >= '3.9' and implementation_name != 'cpython') or (python_full_version >= '3.15' and implementation_name == 'cpython')",
+]
+dependencies = [
+    { name = "execnet", marker = "python_full_version >= '3.9'" },
+    { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", marker = "python_full_version == '3.13.*' and implementation_name == 'cpython'" },
-    { name = "pygments", marker = "python_full_version == '3.13.*' and implementation_name == 'cpython'" },
+    { name = "markdown-it-py", marker = "python_full_version == '3.14.*' and implementation_name == 'cpython'" },
+    { name = "pygments", marker = "python_full_version == '3.14.*' and implementation_name == 'cpython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
 wheels = [
@@ -408,7 +489,7 @@ name = "typing-extensions"
 version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.9' and python_full_version < '3.13') or (python_full_version >= '3.9' and implementation_name != 'cpython') or (python_full_version >= '3.14' and implementation_name == 'cpython')",
+    "(python_full_version >= '3.9' and python_full_version < '3.13') or (python_full_version >= '3.9' and implementation_name != 'cpython') or (python_full_version >= '3.15' and implementation_name == 'cpython')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4", size = 107423, upload-time = "2025-06-02T14:52:11.399Z" }
 wheels = [


### PR DESCRIPTION
This is semi-optimistic concurrency, given 3.14 is still in RC phase. The test suite ran succcessfully locally (see comment in PR). I synced uv.lock under Python 3.8 and 3.140rc2, the changes were idempotent.

I went for
- oldest viable looking Maturin (best availability to end-users)
- newest available pytest (benefit from latest fixes in CI jobs)

Maturin 1.8.7 contains a fix for Python 3.14t on Windows. Maturin 1.9.3 is newest as a I write this.

PyTest 8.4.0 was the first release with official Python 3.14 support. PyTest 8.4.1 is newest as I write this.

See
- https://www.maturin.rs/changelog.html#187
- https://docs.pytest.org/en/stable/changelog.html#pytest-8-4-1-2025-06-17