### PR TITLE
Release v3.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libipld"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2021"
 license = "MIT"
 description = "Python binding to the Rust IPLD library"


### PR DESCRIPTION
# Benchmarks

<img width="1309" height="842" alt="image" src="https://github.com/user-attachments/assets/dffab3b7-67c4-4e48-be38-4519fef2e011" />

## 3.2.0

```
Hello World Decode:
===================
cbrrr    : 272 ns
libipld  : 160 ns

Hello World Encode:
===================
cbrrr    : 227 ns
libipld  : 122 ns

Realistic Decode Tests:
=======================
canada.json.dagcbor            cbrrr    : 4.06 ms (248.37 MB/s)
canada.json.dagcbor            libipld  : 5.95 ms (169.33 MB/s)
citm_catalog.json.dagcbor      cbrrr    : 3.01 ms (108.33 MB/s)
citm_catalog.json.dagcbor      libipld  : 4.78 ms (68.37 MB/s)
github.json.dagcbor            cbrrr    : 0.11 ms (439.66 MB/s)
github.json.dagcbor            libipld  : 0.26 ms (178.59 MB/s)
twitter.json.dagcbor           cbrrr    : 1.52 ms (252.72 MB/s)
twitter.json.dagcbor           libipld  : 2.55 ms (150.68 MB/s)

Realistic Decode Car Tests:
===========================
atproto_repo.car               libipld  : 180.43 ms (153.69 MB/s)

Realistic Encode Tests:
=======================
canada.json.dagcbor            cbrrr    : 1.74 ms (577.59 MB/s)
canada.json.dagcbor            libipld  : 2.00 ms (502.48 MB/s)
citm_catalog.json.dagcbor      cbrrr    : 1.53 ms (212.98 MB/s)
citm_catalog.json.dagcbor      libipld  : 1.77 ms (184.14 MB/s)
github.json.dagcbor            cbrrr    : 0.06 ms (741.36 MB/s)
github.json.dagcbor            libipld  : 0.07 ms (656.01 MB/s)
twitter.json.dagcbor           cbrrr    : 0.68 ms (567.06 MB/s)
twitter.json.dagcbor           libipld  : 0.65 ms (588.30 MB/s)

Decode Torture Tests:
=====================
torture_cids.dagcbor           cbrrr     83.7 ms (46.71 MB/s)
torture_cids.dagcbor           libipld   68.0 ms (57.54 MB/s)
torture_nested_lists.dagcbor   cbrrr     1169.4 ms (8.16 MB/s)
torture_nested_lists.dagcbor   libipld   ERROR: RecursionError: maximum recursion depth exceeded in DAG-CBOR decoding
torture_nested_maps.dagcbor    cbrrr     2016.6 ms (9.46 MB/s)
torture_nested_maps.dagcbor    libipld   ERROR: RecursionError: maximum recursion depth exceeded in DAG-CBOR decoding
```

## 3.3.0

```
Hello World Decode:
===================
cbrrr    : 384 ns
libipld  : 93 ns

Hello World Encode:
===================
cbrrr    : 211 ns
libipld  : 124 ns

Realistic Decode Tests:
=======================
canada.json.dagcbor            cbrrr    : 4.15 ms (242.72 MB/s)
canada.json.dagcbor            libipld  : 4.63 ms (217.38 MB/s)
citm_catalog.json.dagcbor      cbrrr    : 2.63 ms (124.05 MB/s)
citm_catalog.json.dagcbor      libipld  : 2.63 ms (124.10 MB/s)
github.json.dagcbor            cbrrr    : 0.11 ms (439.36 MB/s)
github.json.dagcbor            libipld  : 0.11 ms (424.66 MB/s)
twitter.json.dagcbor           cbrrr    : 1.44 ms (267.47 MB/s)
twitter.json.dagcbor           libipld  : 1.41 ms (272.70 MB/s)

Realistic Decode Car Tests:
===========================
atproto_repo.car               libipld  : 94.67 ms (292.92 MB/s)

Realistic Encode Tests:
=======================
canada.json.dagcbor            cbrrr    : 1.75 ms (574.75 MB/s)
canada.json.dagcbor            libipld  : 2.00 ms (503.18 MB/s)
citm_catalog.json.dagcbor      cbrrr    : 1.64 ms (199.58 MB/s)
citm_catalog.json.dagcbor      libipld  : 1.76 ms (185.11 MB/s)
github.json.dagcbor            cbrrr    : 0.06 ms (798.48 MB/s)
github.json.dagcbor            libipld  : 0.07 ms (707.78 MB/s)
twitter.json.dagcbor           cbrrr    : 0.68 ms (561.15 MB/s)
twitter.json.dagcbor           libipld  : 0.61 ms (630.70 MB/s)

Decode Torture Tests:
=====================
torture_cids.dagcbor           cbrrr     80.3 ms (48.69 MB/s)
torture_cids.dagcbor           libipld   56.1 ms (69.67 MB/s)
torture_nested_lists.dagcbor   cbrrr     1120.2 ms (8.51 MB/s)
torture_nested_lists.dagcbor   libipld   ERROR: RecursionError: maximum recursion depth exceeded in DAG-CBOR decoding
torture_nested_maps.dagcbor    cbrrr     2059.8 ms (9.26 MB/s)
torture_nested_maps.dagcbor    libipld   ERROR: RecursionError: maximum recursion depth exceeded in DAG-CBOR decoding
```

## GPT summary

- Huge speedup on simple decode: 160 ns → 93 ns (**~40% faster**).
- Realistic decode improved a lot: most tests **~25–35% faster.**
- CAR decode massively faster: 180 ms → 94 ms (**~2× faster**).
- Torture CID decode improved: 68 ms → 56 ms (**~17% faster**).
- Realistic encode roughly unchanged.
