### PR TITLE
Fix leading zero handling of CIDs in DAG-CBOR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,12 +38,21 @@ jobs:
             path: dasl-testing
             ref: ${{ env.DASL_TESTING_REF }}
 
+      - name: Build libipld wheel.
+        run: uv build --wheel
+
       - name: Run DASL Python harness.
         working-directory: dasl-testing/harnesses/python
         env:
           UV_PYTHON: "3.13"  # DASL testing requires Python 3.13+
         run: |
-          RESULT_JSON=$(uv run --with cbor2 python main.py libipld)
+          LIBIPLD_WHEEL=$(ls ../../../dist/libipld-*.whl)
+          RESULT_JSON=$(
+            uv run \
+              --with cbor2 \
+              --with "$LIBIPLD_WHEEL" \
+              python main.py libipld
+          )
 
           {
             echo "## DASL Results"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Build libipld wheel.
         run: uv build --wheel
+        env:
+          UV_PYTHON: "3.13"  # DASL testing requires Python 3.13+
 
       - name: Run DASL Python harness.
         working-directory: dasl-testing/harnesses/python

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libipld"
-version = "3.3.1"
+version = "3.3.2"
 edition = "2021"
 license = "MIT"
 description = "Python binding to the Rust IPLD library"

--- a/pytests/test_dag_cbor.py
+++ b/pytests/test_dag_cbor.py
@@ -267,3 +267,13 @@ def test_encode_tag_negative_bignum() -> None:
          libipld.encode_dag_cbor(bignum)
 
     assert 'number out of range' in str(exc_info.value).lower()
+
+
+def test_roundtrip_valid_cid_with_short_tag() -> None:
+    encoded_hex = 'd82a582500015512205891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03'
+    encoded_bytes = bytes.fromhex(encoded_hex)
+
+    decoded = libipld.decode_dag_cbor(encoded_bytes)
+    encoded = libipld.encode_dag_cbor(decoded)
+
+    assert encoded == encoded_bytes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,14 +266,16 @@ where
             // we expect CIDs to have a leading zero byte
             if cid.len() <= 1 || cid[0] != 0 {
                 return Err(anyhow!("Invalid CID"));
-            } 
-        
+            }
+
             let cid_without_prefix = &cid[1..];
             if Cid::try_from(cid_without_prefix).is_err() {
                 return Err(anyhow!("Invalid CID"));
             }
 
-            PyBytes::new(py, cid_without_prefix).into_pyobject(py)?.into()
+            PyBytes::new(py, cid_without_prefix)
+                .into_pyobject(py)?
+                .into()
         }
         major::SIMPLE => match byte {
             // FIXME(MarshalX): should be more clear for bool?


### PR DESCRIPTION
regression after #80, found in #94