### PR TITLE
Optimize DAG-CBOR encode/decode and CAR block parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ anyhow = "1.0.102"
 cid = "0.11.3"
 cbor4ii = { version = "1.2.2" }
 
+[build-dependencies]
+pyo3-build-config = "0.28.3"
+
 [workspace]
 members = [ "profiling" ]
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    if matches!(
+        pyo3_build_config::get().implementation,
+        pyo3_build_config::PythonImplementation::CPython
+    ) {
+        println!("cargo:rustc-cfg=CPython");
+    }
+    println!("cargo:rustc-check-cfg=cfg(CPython)");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,7 @@ fn looks_like_cid(bytes: &[u8]) -> bool {
 }
 
 fn encode_dag_cbor_from_pyobject<'py, W: enc::Write>(
-    py: Python<'py>,
+    _py: Python<'py>,
     obj: &Bound<'py, PyAny>,
     w: &mut W,
 ) -> Result<()>
@@ -384,7 +384,7 @@ where
             types::Map::bounded(entries.len(), w)?;
             for (key, value) in &entries {
                 (&**key).encode(w)?;
-                encode_dag_cbor_from_pyobject(py, value, w)?;
+                encode_dag_cbor_from_pyobject(_py, value, w)?;
             }
             return Ok(());
         }
@@ -394,7 +394,7 @@ where
             types::Array::bounded(len, w)?;
             for i in 0..len {
                 let item = l.get_item_unchecked(i);
-                encode_dag_cbor_from_pyobject(py, &item, w)?;
+                encode_dag_cbor_from_pyobject(_py, &item, w)?;
             }
             return Ok(());
         }
@@ -442,7 +442,7 @@ where
         types::Array::bounded(len, w)?;
         for i in 0..len {
             let item = unsafe { l.get_item_unchecked(i) };
-            encode_dag_cbor_from_pyobject(py, &item, w)?;
+            encode_dag_cbor_from_pyobject(_py, &item, w)?;
         }
         Ok(())
     } else if let Ok(map) = obj.cast::<PyDict>() {
@@ -450,7 +450,7 @@ where
         types::Map::bounded(entries.len(), w)?;
         for (key, value) in &entries {
             (&**key).encode(w)?;
-            encode_dag_cbor_from_pyobject(py, value, w)?;
+            encode_dag_cbor_from_pyobject(_py, value, w)?;
         }
         Ok(())
     } else if let Ok(s) = obj.cast::<PyString>() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Cursor, Write};
+use std::convert::Infallible;
 
 use anyhow::{anyhow, Result};
 use cbor4ii::core::{
@@ -10,28 +10,53 @@ use cid::{multibase, Cid};
 use pyo3::pybacked::PyBackedStr;
 use pyo3::{ffi, prelude::*, types::*, BoundObject, Python};
 
-struct BufWriter<W: io::Write>(io::BufWriter<W>);
+// Private CPython symbol; not provided by pyo3-ffi and CPython-only.
+#[cfg(CPython)]
+extern "C" {
+    fn _PyDict_NewPresized(minused: ffi::Py_ssize_t) -> *mut ffi::PyObject;
+}
 
-impl<W: Write> BufWriter<W> {
-    pub fn new(inner: W) -> Self {
-        BufWriter(io::BufWriter::new(inner))
+// Empty CPython dicts already have 8 slots, so presizing below that buys
+// nothing and lets us stay on the public `PyDict_New` path.
+#[inline]
+unsafe fn new_presized_dict(len: usize) -> *mut ffi::PyObject {
+    #[cfg(CPython)]
+    {
+        if len > 8 {
+            _PyDict_NewPresized(len as ffi::Py_ssize_t)
+        } else {
+            ffi::PyDict_New()
+        }
     }
-
-    pub fn flush(&mut self) -> io::Result<()> {
-        self.0.flush()
-    }
-
-    pub fn get_ref(&self) -> &W {
-        self.0.get_ref()
+    #[cfg(not(CPython))]
+    {
+        let _ = len;
+        ffi::PyDict_New()
     }
 }
 
-impl<W: Write> enc::Write for BufWriter<W> {
-    type Error = io::Error;
+// `enc::Write` over a raw `Vec<u8>`: no syscalls behind it, so a `BufWriter`
+// wrapper would just add a memcpy per push for no benefit.
+struct VecWriter(Vec<u8>);
+
+impl VecWriter {
+    #[inline]
+    fn new() -> Self {
+        VecWriter(Vec::new())
+    }
+
+    #[inline]
+    fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl enc::Write for VecWriter {
+    type Error = Infallible;
 
     #[inline]
     fn push(&mut self, input: &[u8]) -> Result<(), Self::Error> {
-        self.0.write_all(input)?;
+        self.0.extend_from_slice(input);
         Ok(())
     }
 }
@@ -108,40 +133,39 @@ fn map_key_cmp(a: &[u8], b: &[u8]) -> std::cmp::Ordering {
     }
 }
 
-fn sort_map_keys(keys: &Bound<PyList>, len: usize) -> Result<Vec<(PyBackedStr, usize)>> {
-    // Returns key and index.
-    let mut keys_str = Vec::with_capacity(len);
-    for i in 0..len {
-        let item = unsafe { keys.get_item_unchecked(i) };
-        let key = match item.cast::<PyString>() {
-            Ok(k) => k.to_owned(),
+// One dict walk collects (key, value) pairs together; sorting by-index and
+// re-fetching values through `map.values()` would materialize two extra
+// PyLists and walk the dict three times.
+fn collect_and_sort_map_entries<'py>(
+    map: &Bound<'py, PyDict>,
+) -> Result<Vec<(PyBackedStr, Bound<'py, PyAny>)>> {
+    let len = map.len();
+    let mut entries: Vec<(PyBackedStr, Bound<'py, PyAny>)> = Vec::with_capacity(len);
+
+    for (key, value) in map.iter() {
+        let key_str = match key.cast_into::<PyString>() {
+            Ok(k) => k,
             Err(_) => return Err(anyhow!("Map keys must be strings")),
         };
-        let backed_str = match PyBackedStr::try_from(key) {
-            Ok(bs) => bs,
-            Err(_) => return Err(anyhow!("Failed to convert PyString to PyBackedStr")),
-        };
-        keys_str.push((backed_str, i));
+        let backed = PyBackedStr::try_from(key_str)
+            .map_err(|_| anyhow!("Failed to convert PyString to PyBackedStr"))?;
+        entries.push((backed, value));
     }
 
-    if keys_str.len() < 2 {
-        return Ok(keys_str);
+    if entries.len() >= 2 {
+        entries.sort_by(|a, b| {
+            // sort_unstable_by performs bad in past benchmarks; revisit if data shape changes.
+            let (s1, _) = a;
+            let (s2, _) = b;
+            if s1.len() != s2.len() {
+                s1.len().cmp(&s2.len())
+            } else {
+                s1.as_bytes().cmp(s2.as_bytes())
+            }
+        });
     }
 
-    keys_str.sort_by(|a, b| {
-        // sort_unstable_by performs bad
-        let (s1, _) = a;
-        let (s2, _) = b;
-
-        // sorted length-first by the byte representation of the string keys
-        if s1.len() != s2.len() {
-            s1.len().cmp(&s2.len())
-        } else {
-            s1.cmp(s2)
-        }
-    });
-
-    Ok(keys_str)
+    Ok(entries)
 }
 
 fn get_bytes_from_py_any<'py>(obj: &'py Bound<'py, PyAny>) -> PyResult<&'py [u8]> {
@@ -229,7 +253,14 @@ where
         }
         major::MAP => {
             let len = types::Map::len(r)?.ok_or_else(|| anyhow!("Map must contain length"))?;
-            let dict = PyDict::new(py);
+            // Length is known up front; presize to avoid rehashes as we fill.
+            let dict = unsafe {
+                let ptr = new_presized_dict(len);
+                if ptr.is_null() {
+                    return Err(anyhow!(PyErr::fetch(py)));
+                }
+                Bound::from_owned_ptr(py, ptr).cast_into_unchecked::<PyDict>()
+            };
 
             let mut prev_key: Option<&[u8]> = None;
             for _ in 0..len {
@@ -315,109 +346,154 @@ where
     })
 }
 
+// `Cid::try_from` parses two varints + a multihash on every call; this O(1)
+// shape check rejects payloads that can't be a CID without paying for it.
+// CIDv1 starts with `0x01`; CIDv0 is exactly 34 bytes starting `0x12 0x20`.
+#[inline]
+fn looks_like_cid(bytes: &[u8]) -> bool {
+    if bytes.len() < 4 {
+        return false;
+    }
+    if bytes[0] == 0x01 {
+        return true;
+    }
+    bytes.len() == 34 && bytes[0] == 0x12 && bytes[1] == 0x20
+}
+
 fn encode_dag_cbor_from_pyobject<'py, W: enc::Write>(
-    _py: Python<'py>,
+    py: Python<'py>,
     obj: &Bound<'py, PyAny>,
     w: &mut W,
 ) -> Result<()>
 where
     W::Error: Send + Sync,
 {
-    /* Order is important for performance!
+    // Exact-type pointer compare per branch avoids the MRO walk that
+    // `is_instance_of` / `cast` perform. Order tuned for typical ATProto
+    // record shapes; subclasses fall through to the slow path below.
+    let tp = unsafe { ffi::Py_TYPE(obj.as_ptr()) };
+    unsafe {
+        if tp == &raw mut ffi::PyUnicode_Type {
+            let s = obj.cast_unchecked::<PyString>();
+            s.to_str()?.encode(w)?;
+            return Ok(());
+        }
+        if tp == &raw mut ffi::PyDict_Type {
+            let map = obj.cast_unchecked::<PyDict>();
+            let entries = collect_and_sort_map_entries(map)?;
+            types::Map::bounded(entries.len(), w)?;
+            for (key, value) in &entries {
+                (&**key).encode(w)?;
+                encode_dag_cbor_from_pyobject(py, value, w)?;
+            }
+            return Ok(());
+        }
+        if tp == &raw mut ffi::PyList_Type {
+            let l = obj.cast_unchecked::<PyList>();
+            let len = l.len();
+            types::Array::bounded(len, w)?;
+            for i in 0..len {
+                let item = l.get_item_unchecked(i);
+                encode_dag_cbor_from_pyobject(py, &item, w)?;
+            }
+            return Ok(());
+        }
+        if tp == &raw mut ffi::PyLong_Type {
+            return encode_int(obj, w);
+        }
+        if tp == &raw mut ffi::PyBytes_Type {
+            let b = obj.cast_unchecked::<PyBytes>();
+            let bytes = b.as_bytes();
+            if looks_like_cid(bytes) && Cid::try_from(bytes).is_ok() {
+                // by providing custom encoding we avoid extra allocation
+                types::Tag(42, PrefixedCidBytes(bytes)).encode(w)?;
+            } else {
+                types::Bytes(bytes).encode(w)?;
+            }
+            return Ok(());
+        }
+        if tp == &raw mut ffi::PyBool_Type {
+            (obj.as_ptr() == ffi::Py_True()).encode(w)?;
+            return Ok(());
+        }
+        if obj.as_ptr() == ffi::Py_None() {
+            types::Null.encode(w)?;
+            return Ok(());
+        }
+        if tp == &raw mut ffi::PyFloat_Type {
+            let f = obj.cast_unchecked::<PyFloat>();
+            let v = f.value();
+            if !v.is_finite() {
+                return Err(anyhow!("Number out of range"));
+            }
+            v.encode(w)?;
+            return Ok(());
+        }
+    }
 
-    Fast checks go first:
-    - None
-    - bool
-    - int
-    - list
-    - dict
-    - str
-    Then slow checks:
-    - bytes
-    - float
-     */
-
-    if obj.is_none() {
-        types::Null.encode(w)?;
-
-        Ok(())
-    } else if obj.is_instance_of::<PyBool>() {
-        obj.is_truthy()?.encode(w)?;
-
+    // Slow path: subclasses of supported types (rare in DAG-CBOR usage).
+    if obj.is_instance_of::<PyBool>() {
+        (obj.as_ptr() == unsafe { ffi::Py_True() }).encode(w)?;
         Ok(())
     } else if obj.is_instance_of::<PyInt>() {
-        let i: i128 = obj.extract()?;
-
-        if i.is_negative() {
-            if -(i + 1) > u64::MAX as i128 {
-                return Err(anyhow!("Number out of range"));
-            }
-
-            types::Negative(-(i + 1) as u64).encode(w)?;
-        } else {
-            if i > u64::MAX as i128 {
-                return Err(anyhow!("Number out of range"));
-            }
-
-            (i as u64).encode(w)?;
-        }
-
-        Ok(())
+        encode_int(obj, w)
     } else if let Ok(l) = obj.cast::<PyList>() {
         let len = l.len();
-
         types::Array::bounded(len, w)?;
-
         for i in 0..len {
             let item = unsafe { l.get_item_unchecked(i) };
-            encode_dag_cbor_from_pyobject(_py, &item, w)?;
+            encode_dag_cbor_from_pyobject(py, &item, w)?;
         }
-
         Ok(())
     } else if let Ok(map) = obj.cast::<PyDict>() {
-        let len = map.len();
-        let keys = sort_map_keys(&map.keys(), len)?;
-        let values = map.values();
-
-        types::Map::bounded(len, w)?;
-
-        for (key, i) in keys {
-            key.get(..)
-                .ok_or_else(|| anyhow!("Invalid string range while encoding map key"))?
-                .encode(w)?;
-            let value = unsafe { values.get_item_unchecked(i) };
-            encode_dag_cbor_from_pyobject(_py, &value, w)?;
+        let entries = collect_and_sort_map_entries(map)?;
+        types::Map::bounded(entries.len(), w)?;
+        for (key, value) in &entries {
+            (&**key).encode(w)?;
+            encode_dag_cbor_from_pyobject(py, value, w)?;
         }
-
+        Ok(())
+    } else if let Ok(s) = obj.cast::<PyString>() {
+        s.to_str()?.encode(w)?;
+        Ok(())
+    } else if let Ok(b) = obj.cast::<PyBytes>() {
+        let bytes = b.as_bytes();
+        if looks_like_cid(bytes) && Cid::try_from(bytes).is_ok() {
+            types::Tag(42, PrefixedCidBytes(bytes)).encode(w)?;
+        } else {
+            types::Bytes(bytes).encode(w)?;
+        }
         Ok(())
     } else if let Ok(f) = obj.cast::<PyFloat>() {
         let v = f.value();
         if !v.is_finite() {
             return Err(anyhow!("Number out of range"));
         }
-
         v.encode(w)?;
-
-        Ok(())
-    } else if let Ok(b) = obj.cast::<PyBytes>() {
-        // FIXME (MarshalX): it's not efficient to try to parse it as CID
-        let bytes = b.as_bytes();
-        let cid = Cid::try_from(bytes);
-        if cid.is_ok() {
-            // by providing custom encoding we avoid extra allocation
-            types::Tag(42, PrefixedCidBytes(bytes)).encode(w)?;
-        } else {
-            types::Bytes(bytes).encode(w)?;
-        }
-
-        Ok(())
-    } else if let Ok(s) = obj.cast::<PyString>() {
-        s.to_str()?.encode(w)?;
-
         Ok(())
     } else {
         Err(anyhow!("Unknown tag"))
     }
+}
+
+#[inline]
+fn encode_int<W: enc::Write>(obj: &Bound<'_, PyAny>, w: &mut W) -> Result<()>
+where
+    W::Error: Send + Sync,
+{
+    let i: i128 = obj.extract()?;
+    if i.is_negative() {
+        if -(i + 1) > u64::MAX as i128 {
+            return Err(anyhow!("Number out of range"));
+        }
+        types::Negative(-(i + 1) as u64).encode(w)?;
+    } else {
+        if i > u64::MAX as i128 {
+            return Err(anyhow!("Number out of range"));
+        }
+        (i as u64).encode(w)?;
+    }
+    Ok(())
 }
 
 #[pyfunction]
@@ -529,9 +605,10 @@ pub fn decode_car<'py>(py: Python<'py>, data: &[u8]) -> PyResult<(Py<PyAny>, Bou
         }
 
         let cid_bytes_before = buf.buf;
-        let mut cursor = Cursor::new(cid_bytes_before);
-
-        let cid_result = Cid::read_bytes(&mut cursor);
+        // `&[u8]` is itself an `io::Read`, so we hand it to `Cid::read_bytes`
+        // directly and recover the consumed length from the slice shrink.
+        let mut slice: &[u8] = cid_bytes_before;
+        let cid_result = Cid::read_bytes(&mut slice);
         let Ok(cid) = cid_result else {
             return Err(get_err(
                 "Failed to read CID of block",
@@ -546,7 +623,7 @@ pub fn decode_car<'py>(py: Python<'py>, data: &[u8]) -> PyResult<(Py<PyAny>, Bou
             ));
         }
 
-        let consumed = cursor.position() as usize;
+        let consumed = cid_bytes_before.len() - slice.len();
         buf.advance(consumed);
         let cid_raw = &cid_bytes_before[..consumed];
 
@@ -602,14 +679,11 @@ pub fn encode_dag_cbor<'py>(
     py: Python<'py>,
     data: &Bound<'py, PyAny>,
 ) -> PyResult<Bound<'py, PyBytes>> {
-    let mut buf = &mut BufWriter::new(Vec::new());
+    let mut buf = VecWriter::new();
     if let Err(e) = encode_dag_cbor_from_pyobject(py, data, &mut buf) {
         return Err(get_err("Failed to encode DAG-CBOR", e.to_string()));
     }
-    if let Err(e) = buf.flush() {
-        return Err(get_err("Failed to flush buffer", e.to_string()));
-    }
-    Ok(PyBytes::new(py, buf.get_ref()))
+    Ok(PyBytes::new(py, buf.as_slice()))
 }
 
 fn get_cid_from_py_any(data: &Bound<PyAny>) -> PyResult<Cid> {


### PR DESCRIPTION
- Drop `BufWriter<Vec<u8>>`. Write directly into `Vec<u8>` (`VecWriter`)
- Pre-filter CID candidates by leading byte before `Cid::try_from` (`looks_like_cid`)
- Single dict walk in map encode. No more `keys()` + `values()` + by-index lookup
- Exact-type pointer dispatch (`Py_TYPE == &PyXxx_Type`) instead of `is_instance_of` MRO walks
- `_PyDict_NewPresized(len)` for map decode (CPython-only via `cfg(CPython)` + `build.rs`; PyPy falls back to `PyDict_New`); skipped when `len ≤ 8`
- Drop `Cursor` wrapper for `Cid::read_bytes` in `decode_car`, use `&[u8]` directly