### PR TITLE
Optimize int encode with direct PyLong digit read

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,11 +652,49 @@ where
     }
 }
 
+// CPython 3.12+ PyLongObject layout: `PyObject_HEAD; uintptr_t lv_tag; digit ob_digit[]`.
+// `lv_tag` packs the sign in the low 3 bits (0=positive, 1=zero, 2=negative) and the
+// digit count in the upper bits. Default builds use 30-bit digits (uint32_t).
+#[cfg(all(CPython, Py_3_12))]
+#[inline]
+unsafe fn pylong_to_dag_int_fast(obj: *mut ffi::PyObject) -> Option<(u64, bool)> {
+    const NON_SIZE_BITS: u32 = 3;
+    const SIGN_MASK: usize = 3;
+    const SIGN_NEGATIVE: usize = 2;
+    const PYLONG_DIGIT_BITS: u32 = 30;
+
+    let lv_tag_ptr = (obj as *const u8).add(std::mem::size_of::<ffi::PyObject>()) as *const usize;
+    let lv_tag = *lv_tag_ptr;
+    let ndigits = lv_tag >> NON_SIZE_BITS;
+    let neg = (lv_tag & SIGN_MASK) == SIGN_NEGATIVE;
+
+    let ob_digit = lv_tag_ptr.add(1) as *const u32;
+    let abs_val: u64 = match ndigits {
+        0 => return Some((0, false)),
+        1 => *ob_digit as u64,
+        2 => (*ob_digit as u64) | ((*ob_digit.add(1) as u64) << PYLONG_DIGIT_BITS),
+        _ => return None,
+    };
+    Some((abs_val, neg))
+}
+
 #[inline]
 fn encode_int<W: enc::Write>(obj: &Bound<'_, PyAny>, w: &mut W) -> Result<()>
 where
     W::Error: Send + Sync,
 {
+    #[cfg(all(CPython, Py_3_12))]
+    {
+        if let Some((abs_val, neg)) = unsafe { pylong_to_dag_int_fast(obj.as_ptr()) } {
+            if neg {
+                types::Negative(abs_val - 1).encode(w)?;
+            } else {
+                abs_val.encode(w)?;
+            }
+            return Ok(());
+        }
+    }
+
     let i: i128 = obj.extract()?;
     if i.is_negative() {
         if -(i + 1) > u64::MAX as i128 {


### PR DESCRIPTION
Adds a CPython 3.12+ fast path in `encode_int` that reads `PyLongObject.lv_tag` + `ob_digit[0..2]` directly to encode 0/1/2-digit ints (≤ 2**60), skipping `obj.extract::<i128>()` which internally calls `_PyLong_AsByteArray` with a 16-byte buffer + sign check on every int

Ints requiring 3+ digits, pre-3.12, and non-CPython fall through to the existing `i128` path, which still enforces the +-2**64 DAG-CBOR range